### PR TITLE
Solucionada incidencia gestion Sin clasificar

### DIFF
--- a/script.js
+++ b/script.js
@@ -189,6 +189,9 @@ function isBookInAnySubsection(book, classification) {
         const section = classification.sections[sectionKey];
         for (const subKey in section.subsections) {
             const subsection = section.subsections[subKey];
+            if (normalizeText(subsection.name) === normalizeText('Sin clasificar')) {
+                continue;
+            }
             const subsectionTags = (subsection.tags || []).map(normalizeText);
             if (subsectionTags.some(tag => bookTags.includes(tag))) {
                 return true;


### PR DESCRIPTION
 hay una incidencia en Biblioteca que creo que consiste en lo siguiente: cuando se buscan los libros que no están clasificados en ninguna subsección para ponerles el tag Sin clasificar, no tiene en cuenta que si  está en la subsección Sin clasificar no hay que tenerla en cuenta, es decir para pone un libro el tag Sin clasificar no tiene que estar en ninguna o solo en la subseccion Sin Clasificar y para quitarle esta  etiqueta tiene que estar en alguna subseccion que no sea la de Sin clasificar.